### PR TITLE
Add pinact and zizmor workflow checks

### DIFF
--- a/.github/workflows/pinact.yaml
+++ b/.github/workflows/pinact.yaml
@@ -1,0 +1,34 @@
+name: Pinact
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - "action.yml"
+      - "action.yaml"
+
+permissions: {}
+
+jobs:
+  pinact:
+    # Only run on pull requests from the same repository
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Pin actions
+        uses: suzuki-shunsuke/pinact-action@cf51507d80d4d6522a07348e3d58790290eaf0b6 # v2.0.0
+        with:
+          skip_push: true
+          verify: true
+          min_age: 7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,12 +16,12 @@ jobs:
     if: github.event.type != 'pull_request'
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       with:
         fetch-depth: 0
 
     - name: Prepare release
-      uses: labd/changie-release-action@v0.1.1
+      uses: labd/changie-release-action@2acb1823176f24cf26cd699b82c4ad7639190ae6 # v0.1.1
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         release-workflow: ''

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,32 @@
+name: Zizmor
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        with:
+          advanced-security: false
+          annotations: true
+          min-severity: high

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
   using: 'composite'
   steps:
     - name: Install MACH composer
-      uses: mach-composer/setup-mach-composer@main
+      uses: mach-composer/setup-mach-composer@3ca0bd4e2c0f08fefc803a36fcbba70e5ee00d67 # main
       with:
         version: ${{ inputs.mach_composer_version }}
 
@@ -43,9 +43,13 @@ runs:
         MCC_DEBUG: 1
         MCC_CLIENT_ID: ${{ inputs.client_id }}
         MCC_CLIENT_SECRET: ${{ inputs.client_secret }}
+        INPUT_ORGANIZATION: ${{ inputs.organization }}
+        INPUT_PROJECT: ${{ inputs.project }}
+        INPUT_COMPONENT: ${{ inputs.component }}
+        INPUT_ARGS: ${{ inputs.args }}
       run: |
         mach-composer cloud register-component-version \
-          --organization ${{ inputs.organization }} \
-          --project ${{ inputs.project }} \
-          --auto ${{ inputs.component }} \
-          ${{ inputs.args }}
+          --organization "$INPUT_ORGANIZATION" \
+          --project "$INPUT_PROJECT" \
+          --auto "$INPUT_COMPONENT" \
+          $INPUT_ARGS


### PR DESCRIPTION
## Summary
- Add pinact workflow to verify GitHub Actions are pinned to commit SHAs
- Add zizmor workflow to audit GitHub Actions for security issues
- Pin all existing actions to commit SHAs